### PR TITLE
Fix converting null values from DB to PHP

### DIFF
--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -109,6 +109,9 @@ final class JsonDocumentType extends JsonArrayType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if ($value === null) {
+            return null;   
+        }
         return $this->getSerializer()->deserialize($value, '', $this->format, $this->deserializationContext);
     }
 


### PR DESCRIPTION
When the column of `json_document` type is `nullable` and it is empty, an exception is thrown during reading it from database:

```
Syntax Error
in vendor\symfony\symfony\src\Symfony\Component\Serializer\Encoder\JsonDecode.php at line 91 
```

Small null-check before deserialization fixes the problem.