### PR TITLE
Fix denormalize object nested an other object

### DIFF
--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -60,6 +60,10 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (is_object($data)) {
+            return $data;
+        }
+
         if (isset($data['#type'])) {
             $type = $data['#type'];
             unset($data['#type']);

--- a/tests/Fixtures/TestBundle/Entity/Attributes.php
+++ b/tests/Fixtures/TestBundle/Entity/Attributes.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity;
+
+class Attributes
+{
+    private $attributes = [];
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function addAttributes(Attribute $attribute)
+    {
+        $this->attributes[] = $attribute;
+    }
+}

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -10,6 +10,7 @@
 namespace Dunglas\DoctrineJsonOdm\tests;
 
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Attribute;
+use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Attributes;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Bar;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Baz;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Foo;
@@ -119,6 +120,34 @@ class FunctionalTest extends KernelTestCase
         $manager->clear();
 
         $foo = $manager->find(Foo::class, $foo->getId());
+        $this->assertEquals($misc, $foo->getMisc());
+    }
+
+    public function testNestedObjectsInNestedObject()
+    {
+        $attribute1 = new Attribute();
+        $attribute1->key = 'attribute1';
+
+        $attribute2 = new Attribute();
+        $attribute2->key = 'attribute2';
+
+        $attributes = new Attributes();
+        $attributes->setAttributes([$attribute1, $attribute2]);
+
+        $misc = [$attributes];
+
+        $foo = new Foo();
+        $foo->setName('foo');
+        $foo->setMisc($misc);
+
+        $manager = self::$kernel->getContainer()->get('doctrine')->getManagerForClass(Foo::class);
+
+        $manager->persist($foo);
+        $manager->flush();
+        $manager->clear();
+
+        $foo = $manager->find(Foo::class, $foo->getId());
+
         $this->assertEquals($misc, $foo->getMisc());
     }
 }


### PR DESCRIPTION
Use case:
You have some `Attribute` nested in an `Attributes` object who are nested in a `Foo` object.

Issue:
If you have a mutator for your `Attribute` object and you typehint it, you can have an Exception message like this:
`
Error: Cannot use object of type Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Attribute as array 
`