### PR TITLE
add requiresSQLCommentHint to fix db sync in doctrine

### DIFF
--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -136,6 +136,14 @@ final class JsonDocumentType extends InternalParentClass
     /**
      * {@inheritdoc}
      */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'json_document';


### PR DESCRIPTION
Fixes #11 

The added comment hint helps doctrine to detect automatic syncing with DB. Tested already in our project and works well.

BC break: Only MySQL comment is added

Not tested: Postgres, but should not be a problem, because it's a default Doctrine option.

Image from our project:

![image](https://user-images.githubusercontent.com/546813/36984012-220acbb4-2094-11e8-9345-1f60f4b58240.png)
