### PR TITLE
Fixed wrong recursion which causes side effects

### DIFF
--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -68,7 +68,6 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
             $type = $data['#type'];
             unset($data['#type']);
 
-            $data = $this->denormalize($data, $type, $format, $context);
             $data = $this->objectNormalizer->denormalize($data, $type, $format, $context);
 
             return $data;

--- a/tests/Fixtures/TestBundle/Entity/Attribute.php
+++ b/tests/Fixtures/TestBundle/Entity/Attribute.php
@@ -14,6 +14,13 @@ namespace Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity;
  */
 class Attribute
 {
+    /**
+     * @var string
+     */
     public $key;
+
+    /**
+     * @var string|Attribute[][]
+     */
     public $value;
 }


### PR DESCRIPTION
This is the one that was causing major issues on my side. I figured pretty quickly that when I just commented that one out, everything worked as expected for me. However, the unit tests then failed.
After a long debugging session first on my own and then with the help of @aschempp we finally found that it was just the annotations that were missing, causing the tests to fail. The object normalizer requires them to be present, otherwise it doesn't work properly.

This is also a huge speed gain because it removes useless recursive calls 😄 