### PR TITLE
Do not store null as a string

### DIFF
--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -118,6 +118,10 @@ final class JsonDocumentType extends InternalParentClass
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
+        if (null === $value) {
+            return;
+        }
+
         return $this->getSerializer()->serialize($value, $this->format, $this->serializationContext);
     }
 

--- a/tests/Fixtures/TestBundle/Entity/Product.php
+++ b/tests/Fixtures/TestBundle/Entity/Product.php
@@ -31,7 +31,7 @@ class Product
     public $name;
 
     /**
-     * @ORM\Column(type="json_document", options={"jsonb": true})
+     * @ORM\Column(type="json_document", options={"jsonb": true}, nullable=true)
      */
     public $attributes;
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -150,4 +150,23 @@ class FunctionalTest extends KernelTestCase
 
         $this->assertEquals($misc, $foo->getMisc());
     }
+
+    public function testNullIsStoredAsNull()
+    {
+        $product = new Product();
+        $product->name = 'My product';
+        $product->attributes = null;
+
+        $manager = self::$kernel->getContainer()->get('doctrine')->getManagerForClass(Product::class);
+        $manager->persist($product);
+        $manager->flush();
+        $manager->clear();
+
+        $connection = $manager->getConnection();
+
+        $stmt = $connection->prepare('SELECT * FROM product');
+        $stmt->execute();
+
+        $this->assertNull($stmt->fetch()['attributes']);
+    }
 }


### PR DESCRIPTION
If you want to store `null` right now, what happens that in the DB you'll have the string representation `null` stored instead of having the DB really setting it to null.

It's not a problem for the serializer but you cannot query the DB with e.g. `IS NOT NULL`.