### PR TITLE
Adding support for schema tooling to use the correct column type

### DIFF
--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -142,7 +142,7 @@ final class JsonDocumentType extends InternalParentClass
      */
     public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return sprintf('JSON');
+        return 'JSON';
     }
 
     /**

--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -136,7 +136,7 @@ final class JsonDocumentType extends InternalParentClass
 
         return $this->getSerializer()->deserialize($value, '', $this->format, $this->deserializationContext);
     }
-      
+
     /**
      * {@inheritdoc}
      */
@@ -144,7 +144,7 @@ final class JsonDocumentType extends InternalParentClass
     {
         return sprintf('JSON');
     }
-    
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Using the schema management commands would complain that the type was JSON and thought it should be LONGTEXT.