### PR TITLE
Allow objects normalized to scalar values

### DIFF
--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -44,7 +44,9 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        return array_merge(['#type' => ClassUtils::getClass($object)], $this->objectNormalizer->normalize($object, $format, $context));
+        $data = $this->objectNormalizer->normalize($object, $format, $context);
+
+        return array_merge(['#type' => ClassUtils::getClass($object)], is_scalar($data) ? ['#scalar' => $data] : $data);
     }
 
     /**
@@ -68,6 +70,7 @@ final class ObjectNormalizer implements NormalizerInterface, DenormalizerInterfa
             $type = $data['#type'];
             unset($data['#type']);
 
+            $data = isset($data['#scalar']) ? $data['#scalar'] : $data;
             $data = $this->denormalize($data, $type, $format, $context);
             $data = $this->objectNormalizer->denormalize($data, $type, $format, $context);
 

--- a/tests/Fixtures/ScalarValue.php
+++ b/tests/Fixtures/ScalarValue.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\DoctrineJsonOdm\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Fixture class to test object normalized as scalar values
+ *
+ * @author Antonio J. García Lagar <aj@garcialagar.es>
+ */
+class ScalarValue implements NormalizableInterface, DenormalizableInterface
+{
+    private $value;
+
+    public function __construct($value = '')
+    {
+        $this->value = $value;
+    }
+
+    public function value()
+    {
+        return $this->value;
+    }
+
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
+    {
+        return $this->value;
+    }
+
+    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = [])
+    {
+        $this->value = $data;
+
+        return $this;
+    }
+}

--- a/tests/Normalizer/ObjectNormalizerTest.php
+++ b/tests/Normalizer/ObjectNormalizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\DoctrineJsonOdm\tests\Normalizer;
+
+use Dunglas\DoctrineJsonOdm\Normalizer\ObjectNormalizer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+class ObjectNormalizerTest extends TestCase
+{
+    public function testObjectToScalarNormalization()
+    {
+        $normalizer = new ObjectNormalizer(new CustomNormalizer());
+        $serializer = new Serializer([$normalizer], [new JsonEncoder()]);
+
+        $data = $serializer->normalize(new ScalarValue('foobar'));
+        $this->assertArrayHasKey('#type', $data);
+        $this->assertArrayHasKey('#scalar', $data);
+
+        $object = $serializer->denormalize($data, ScalarValue::class);
+        $this->assertInstanceOf(ScalarValue::class, $object);
+        $this->assertSame('foobar', $object->value());
+    }
+}
+
+class ScalarValue implements NormalizableInterface, DenormalizableInterface
+{
+    private $value;
+
+    public function __construct(string $value = '')
+    {
+        $this->value = $value;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
+    {
+        return $this->value;
+    }
+
+    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = [])
+    {
+        $this->value = $data;
+
+        return $this;
+    }
+}

--- a/tests/Normalizer/ObjectNormalizerTest.php
+++ b/tests/Normalizer/ObjectNormalizerTest.php
@@ -10,13 +10,10 @@
 namespace Dunglas\DoctrineJsonOdm\tests\Normalizer;
 
 use Dunglas\DoctrineJsonOdm\Normalizer\ObjectNormalizer;
+use Dunglas\DoctrineJsonOdm\Tests\Fixtures\ScalarValue;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
-use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
 
 class ObjectNormalizerTest extends TestCase
@@ -33,32 +30,5 @@ class ObjectNormalizerTest extends TestCase
         $object = $serializer->denormalize($data, ScalarValue::class);
         $this->assertInstanceOf(ScalarValue::class, $object);
         $this->assertSame('foobar', $object->value());
-    }
-}
-
-class ScalarValue implements NormalizableInterface, DenormalizableInterface
-{
-    private $value;
-
-    public function __construct(string $value = '')
-    {
-        $this->value = $value;
-    }
-
-    public function value(): string
-    {
-        return $this->value;
-    }
-
-    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
-    {
-        return $this->value;
-    }
-
-    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = [])
-    {
-        $this->value = $data;
-
-        return $this;
     }
 }


### PR DESCRIPTION
I'm using a custom normalizer that normalizes some value objects to scalar.

This PR restores the ability to handle object normalized to scalar values removed in https://github.com/dunglas/doctrine-json-odm/commit/55a499ca724c780d2ce62fb077e5c4e1c5f96c72.