### PR TITLE
Added failed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ As an example we use the Symfony `DateTimeNormalizer` service so we do have supp
     dunglas_doctrine_json_odm.serializer:
         class: Symfony\Component\Serializer\Serializer
         arguments:
-          - ['@serializer.normalizer.datetime', '@dunglas_doctrine_json_odm.normalizer.object']
+          - ['@dunglas_doctrine_json_odm.normalizer.array', '@serializer.normalizer.datetime', '@dunglas_doctrine_json_odm.normalizer.object']
           - ['@serializer.encoder.json']
         public: true
 ```

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="dunglas_doctrine_json_odm.normalizer.raw_object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
+        <service id="dunglas_doctrine_json_odm.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
             <argument>null</argument><!-- name converter -->
             <argument type="service" id="serializer.property_accessor" />
@@ -18,7 +18,7 @@
         <service id="dunglas_doctrine_json_odm.serializer" class="Dunglas\DoctrineJsonOdm\Serializer" public="true">
             <argument type="collection">
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.array" />
-                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.raw_object" />
+                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.object" />
             </argument>
 
             <argument type="collection">

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -5,10 +5,20 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="dunglas_doctrine_json_odm.normalizer.raw_object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
+            <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
+            <argument>null</argument><!-- name converter -->
+            <argument type="service" id="serializer.property_accessor" />
+            <argument type="service" id="property_info" on-invalid="ignore" />
+            <argument type="service" id="serializer.mapping.class_discriminator_resolver" on-invalid="ignore" />
+        </service>
+
+        <service id="dunglas_doctrine_json_odm.normalizer.array" class="Symfony\Component\Serializer\Normalizer\ArrayDenormalizer" public="false" />
+
         <service id="dunglas_doctrine_json_odm.serializer" class="Dunglas\DoctrineJsonOdm\Serializer" public="true">
             <argument type="collection">
-                <argument type="service" id="serializer.denormalizer.array" />
-                <argument type="service" id="serializer.normalizer.object" />
+                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.array" />
+                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.raw_object" />
             </argument>
 
             <argument type="collection">

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -17,7 +17,6 @@ use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Foo;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Product;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\ScalarValue;
 use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Serializer\Serializer;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -164,31 +163,35 @@ class FunctionalTest extends AbstractKernelTestCase
         $this->assertNull($stmt->fetch()['attributes']);
     }
 
-	public function testStoreAndRetrieveDocumentWithInstantiatedOtherSerializer()
-	{
-		$serializer = self::$kernel->getContainer()->get('serializer');
+    public function testStoreAndRetrieveDocumentWithInstantiatedOtherSerializer()
+    {
+        /**
+         * This call is necessary to cover this issue
+         * @see https://github.com/dunglas/doctrine-json-odm/pull/78
+         */
+        $serializer = self::$kernel->getContainer()->get('serializer');
 
-		$attribute1 = new Attribute();
-		$attribute1->key = 'foo';
-		$attribute1->value = 'bar';
+        $attribute1 = new Attribute();
+        $attribute1->key = 'foo';
+        $attribute1->value = 'bar';
 
-		$attribute2 = new Attribute();
-		$attribute2->key = 'weights';
-		$attribute2->value = [34, 67];
+        $attribute2 = new Attribute();
+        $attribute2->key = 'weights';
+        $attribute2->value = [34, 67];
 
-		$attributes = [$attribute1, $attribute2];
+        $attributes = [$attribute1, $attribute2];
 
-		$product = new Product();
-		$product->name = 'My product';
-		$product->attributes = $attributes;
+        $product = new Product();
+        $product->name = 'My product';
+        $product->attributes = $attributes;
 
-		$manager = self::$kernel->getContainer()->get('doctrine')->getManagerForClass(Product::class);
-		$manager->persist($product);
-		$manager->flush();
+        $manager = self::$kernel->getContainer()->get('doctrine')->getManagerForClass(Product::class);
+        $manager->persist($product);
+        $manager->flush();
 
-		$manager->clear();
+        $manager->clear();
 
-		$retrievedProduct = $manager->find(Product::class, $product->id);
-		$this->assertEquals($attributes, $retrievedProduct->attributes);
-	}
+        $retrievedProduct = $manager->find(Product::class, $product->id);
+        $this->assertEquals($attributes, $retrievedProduct->attributes);
+    }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -17,6 +17,7 @@ use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Foo;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Product;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\ScalarValue;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Serializer\Serializer;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -162,4 +163,32 @@ class FunctionalTest extends AbstractKernelTestCase
 
         $this->assertNull($stmt->fetch()['attributes']);
     }
+
+	public function testStoreAndRetrieveDocumentWithInstantiatedOtherSerializer()
+	{
+		$serializer = self::$kernel->getContainer()->get('serializer');
+
+		$attribute1 = new Attribute();
+		$attribute1->key = 'foo';
+		$attribute1->value = 'bar';
+
+		$attribute2 = new Attribute();
+		$attribute2->key = 'weights';
+		$attribute2->value = [34, 67];
+
+		$attributes = [$attribute1, $attribute2];
+
+		$product = new Product();
+		$product->name = 'My product';
+		$product->attributes = $attributes;
+
+		$manager = self::$kernel->getContainer()->get('doctrine')->getManagerForClass(Product::class);
+		$manager->persist($product);
+		$manager->flush();
+
+		$manager->clear();
+
+		$retrievedProduct = $manager->find(Product::class, $product->id);
+		$this->assertEquals($attributes, $retrievedProduct->attributes);
+	}
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -166,7 +166,8 @@ class FunctionalTest extends AbstractKernelTestCase
     public function testStoreAndRetrieveDocumentWithInstantiatedOtherSerializer()
     {
         /**
-         * This call is necessary to cover this issue
+         * This call is necessary to cover this issue.
+         *
          * @see https://github.com/dunglas/doctrine-json-odm/pull/78
          */
         $serializer = self::$kernel->getContainer()->get('serializer');


### PR DESCRIPTION
I have added a test which shows my issue - if you (or DI) instantiate basic symfony serializer, it invokes `setSerializer` method of all `SerializerAware` services and rewrites `serializer` property from `DunglasSerializer` to `SymfobySerializer`.
This breaks the further normalization.