### PR TITLE
fix: serializer

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -44,7 +44,7 @@ final class Serializer extends BaseSerializer
         if (is_iterable($data)) {
             $class = ('' === $class) ? 'stdClass' : $class;
 
-            return parent::denormalize($data, $class.'[]', $format, $context);
+            return parent::denormalize($data, $class, $format, $context);
         }
 
         return $data;


### PR DESCRIPTION
Array in return parent::denormalize($data, $class.'[]', $format, $context); should not exist anymore since it's natively handle by symfony/serializer