### PR TITLE
Add return types to support Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.0",
     "doctrine/orm": "^2.6.3",
     "symfony/property-access": "^3.4 || ^4.1 || ^5.0 || ^6.0",
     "symfony/property-info": "^3.4 || ^4.1 || ^5.0 || ^6.0",

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -16,7 +16,7 @@ final class Serializer extends BaseSerializer
     private const KEY_TYPE = '#type';
     private const KEY_SCALAR = '#scalar';
 
-    public function normalize($data, $format = null, array $context = [])
+    public function normalize(mixed $data, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalizedData = parent::normalize($data, $format, $context);
 
@@ -29,7 +29,7 @@ final class Serializer extends BaseSerializer
         return $normalizedData;
     }
 
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize(mixed $data, string $class, string $format = null, array $context = []): mixed
     {
         if (\is_array($data) && (isset($data[self::KEY_TYPE]))) {
             $type = $data[self::KEY_TYPE];

--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -37,32 +37,18 @@ if (class_exists(JsonType::class)) {
  */
 final class JsonDocumentType extends InternalParentClass
 {
-    /**
-     * @var SerializerInterface
-     */
-    private $serializer;
+    private SerializerInterface $serializer;
 
-    /**
-     * @var string
-     */
-    private $format = 'json';
+    private string $format = 'json';
 
-    /**
-     * @var array
-     */
-    private $serializationContext = [];
+    private array $serializationContext = [];
 
-    /**
-     * @var array
-     */
-    private $deserializationContext = [];
+    private array $deserializationContext = [];
 
     /**
      * Sets the serializer to use.
-     *
-     * @param SerializerInterface $serializer
      */
-    public function setSerializer(SerializerInterface $serializer)
+    public function setSerializer(SerializerInterface $serializer): void
     {
         $this->serializer = $serializer;
     }
@@ -71,10 +57,8 @@ final class JsonDocumentType extends InternalParentClass
      * Gets the serializer or throw an exception if it isn't available.
      *
      * @throws \RuntimeException
-     *
-     * @return SerializerInterface
      */
-    private function getSerializer()
+    private function getSerializer(): SerializerInterface
     {
         if (null === $this->serializer) {
             throw new \RuntimeException(sprintf('An instance of "%s" must be available. Call the "setSerializer" method.', SerializerInterface::class));
@@ -85,30 +69,24 @@ final class JsonDocumentType extends InternalParentClass
 
     /**
      * Sets the serialization format (default to "json").
-     *
-     * @param string $format
      */
-    public function setFormat($format)
+    public function setFormat(string $format): void
     {
         $this->format = $format;
     }
 
     /**
      * Sets the serialization context (default to an empty array).
-     *
-     * @param array $serializationContext
      */
-    public function setSerializationContext(array $serializationContext)
+    public function setSerializationContext(array $serializationContext): void
     {
         $this->serializationContext = $serializationContext;
     }
 
     /**
      * Sets the deserialization context (default to an empty array).
-     *
-     * @param array $deserializationContext
      */
-    public function setDeserializationContext(array $deserializationContext)
+    public function setDeserializationContext(array $deserializationContext): void
     {
         $this->deserializationContext = $deserializationContext;
     }
@@ -116,10 +94,10 @@ final class JsonDocumentType extends InternalParentClass
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
         if (null === $value) {
-            return;
+            return null;
         }
 
         return $this->getSerializer()->serialize($value, $this->format, $this->serializationContext);
@@ -128,10 +106,10 @@ final class JsonDocumentType extends InternalParentClass
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         if (null === $value || $value === '') {
-            return;
+            return null;
         }
 
         return $this->getSerializer()->deserialize($value, '', $this->format, $this->deserializationContext);
@@ -140,7 +118,7 @@ final class JsonDocumentType extends InternalParentClass
     /**
      * {@inheritdoc}
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }
@@ -148,7 +126,7 @@ final class JsonDocumentType extends InternalParentClass
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'json_document';
     }

--- a/tests/Fixtures/TestBundle/Entity/Bar.php
+++ b/tests/Fixtures/TestBundle/Entity/Bar.php
@@ -14,37 +14,25 @@ namespace Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity;
  */
 class Bar
 {
-    private $title;
-    private $weight;
+    private mixed $title;
+    private mixed $weight;
 
-    /**
-     * @return mixed
-     */
-    public function getTitle()
+    public function getTitle(): mixed
     {
         return $this->title;
     }
 
-    /**
-     * @param mixed $title
-     */
-    public function setTitle($title)
+    public function setTitle(mixed $title)
     {
         $this->title = $title;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getWeight()
+    public function getWeight(): mixed
     {
         return $this->weight;
     }
 
-    /**
-     * @param mixed $weight
-     */
-    public function setWeight($weight)
+    public function setWeight(mixed $weight)
     {
         $this->weight = $weight;
     }

--- a/tests/Fixtures/TestBundle/Entity/ScalarValue.php
+++ b/tests/Fixtures/TestBundle/Entity/ScalarValue.php
@@ -33,7 +33,7 @@ class ScalarValue implements NormalizableInterface, DenormalizableInterface
         return $this->value;
     }
 
-    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = []): array|string|int|float|bool
     {
         return $this->value;
     }


### PR DESCRIPTION
* Add return types that fix compatibility with Symfony 6.
* Add other argument and return types too.
* Raise PHP version requirement to 8.0 for union types.

BREAKING CHANGE: requires PHP 8.0 for union types.

Fix #99, ref #101.
