### PR TITLE
Allow using type names in place of class names

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Dunglas\DoctrineJsonOdm\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('dunglas_doctrine_json_odm');
+
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('types')
+                    ->defaultValue([])
+                    ->useAttributeAsKey('type')
+                    ->scalarPrototype()
+                        ->cannotBeEmpty()
+                        ->validate()
+                            ->ifTrue(static function ($v): bool {
+                                return !class_exists($v);
+                            })
+                            ->thenInvalid('Use fully qualified classnames as type values')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/Bundle/DependencyInjection/DunglasDoctrineJsonOdmExtension.php
+++ b/src/Bundle/DependencyInjection/DunglasDoctrineJsonOdmExtension.php
@@ -9,6 +9,7 @@
 
 namespace Dunglas\DoctrineJsonOdm\Bundle\DependencyInjection;
 
+use Dunglas\DoctrineJsonOdm\TypeMapper;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -50,5 +51,8 @@ final class DunglasDoctrineJsonOdmExtension extends Extension implements Prepend
         if (!class_exists(BackedEnumNormalizer::class) || !class_exists(\BackedEnum::class)) {
             $container->removeDefinition('dunglas_doctrine_json_odm.normalizer.backed_enum');
         }
+
+        $config = $this->processConfiguration(new Configuration(), $configs);
+        $container->setParameter('dunglas_doctrine_json_odm.type_map', $config['types']);
     }
 }

--- a/src/Bundle/DunglasDoctrineJsonOdmBundle.php
+++ b/src/Bundle/DunglasDoctrineJsonOdmBundle.php
@@ -11,6 +11,7 @@ namespace Dunglas\DoctrineJsonOdm\Bundle;
 
 use Doctrine\DBAL\Types\Type;
 use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
+use Dunglas\DoctrineJsonOdm\TypeMapper;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -34,5 +35,7 @@ final class DunglasDoctrineJsonOdmBundle extends Bundle
     {
         $type = Type::getType('json_document');
         $type->setSerializer($this->container->get('dunglas_doctrine_json_odm.serializer'));
+
+        TypeMapper::$map = $this->container->getParameter('dunglas_doctrine_json_odm.type_map');
     }
 }

--- a/src/SerializerTrait.php
+++ b/src/SerializerTrait.php
@@ -27,7 +27,8 @@ trait SerializerTrait
         $normalizedData = parent::normalize($data, $format, $context);
 
         if (\is_object($data)) {
-            $typeData = [self::KEY_TYPE => \get_class($data)];
+            $typeName = TypeMapper::getTypeByClass(\get_class($data));
+            $typeData = [self::KEY_TYPE => $typeName];
             $valueData = is_scalar($normalizedData) ? [self::KEY_SCALAR => $normalizedData] : $normalizedData;
             $normalizedData = array_merge($typeData, $valueData);
         }
@@ -43,7 +44,7 @@ trait SerializerTrait
     public function denormalize($data, $type, $format = null, array $context = [])
     {
         if (\is_array($data) && (isset($data[self::KEY_TYPE]))) {
-            $keyType = $data[self::KEY_TYPE];
+            $keyType = TypeMapper::getClassByType($data[self::KEY_TYPE]);
             unset($data[self::KEY_TYPE]);
 
             $data = $data[self::KEY_SCALAR] ?? $data;

--- a/src/TypeMapper.php
+++ b/src/TypeMapper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Dunglas\DoctrineJsonOdm;
+
+/**
+ * Allows using string constants in place of class names
+ */
+class TypeMapper
+{
+    /**
+     * @var array<class-string, string>
+     */
+    public static $map;
+
+    /**
+     * Falls back to class name itself
+     * @param class-string $class
+     */
+    public static function getTypeByClass(string $class): string
+    {
+        $type = array_search($class, self::$map);
+
+        return $type ?: $class;
+    }
+
+    /**
+     * Falls back to type name itself – it might as well be a class
+     * @return class-string
+     */
+    public static function getClassByType(string $type): string
+    {
+        return self::$map[$type] ?? $type;
+    }
+}


### PR DESCRIPTION
## Introduce bundle config to map keys to class names

See https://github.com/dunglas/doctrine-json-odm/issues/63

The static type mapper might seem to be weird but this way we don't need to inject anything extra into the serializer and we do not break BC, especially given the doc encourages overriding the service definition.

Comments welcome, let me know what you think, I'll add tests if it can go forward