### PR TITLE
Add a note about DateTimeNormalizer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ use Dunglas\DoctrineJsonOdm\Serializer;
 use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 if (!Type::hasType('json_document')) {
     Type::addType('json_document', JsonDocumentType::class);
     Type::getType('json_document')->setSerializer(
-        new Serializer([new ArrayDenormalizer(), new ObjectNormalizer()], [new JsonEncoder()])
+        new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), new ObjectNormalizer()], [new JsonEncoder()])
     );
 }
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ use Dunglas\DoctrineJsonOdm\Serializer;
 use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 if (!Type::hasType('json_document')) {
     Type::addType('json_document', JsonDocumentType::class);
     Type::getType('json_document')->setSerializer(
-        new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), new ObjectNormalizer()], [new JsonEncoder()])
+        new Serializer([new BackedEnumNormalizer(), new DateTimeNormalizer(), new ArrayDenormalizer(), new ObjectNormalizer()], [new JsonEncoder()])
     );
 }
 
@@ -215,7 +216,6 @@ For using the built-in type mapper:
     );
 ```
 
-
 ### Limitations when updating nested properties
 
 Due to how Doctrine works, it will not detect changes to nested objects or properties.
@@ -292,20 +292,22 @@ class Kernel extends BaseKernel
 
 **How can I add additional normalizers?**
 
-The Symfony Serializer is easily extensible. This bundle registers and uses a service with ID `dunglas_doctrine_json_odm.serializer` as the serializer for the JSON type. This means we can easily override it in our `services.yaml` to use additional normalizers.
-As an example we use the Symfony `DateTimeNormalizer` service, so we do have support for any property that is an instance of `\DateTimeInterface`. Be aware that the order of the normalizers might be relevant depending on the normalizers you use.
+The Symfony Serializer is easily extensible. This bundle registers and uses a service with ID `dunglas_doctrine_json_odm.serializer` as the serializer for the JSON type.
+This means we can easily override it in our `services.yaml` to use additional normalizers.
+As an example we inject a custom normalizer service. Be aware that the order of the normalizers might be relevant depending on the normalizers you use.
 
 ```yaml
     # Add DateTime Normalizer to Dunglas' Doctrine JSON ODM Bundle
     dunglas_doctrine_json_odm.serializer:
         class: Dunglas\DoctrineJsonOdm\Serializer
         arguments:
-          - ['@dunglas_doctrine_json_odm.normalizer.array', '@serializer.normalizer.datetime', '@dunglas_doctrine_json_odm.normalizer.object']
+          - ['@App\MyCustom\Normalizer', '@?dunglas_doctrine_json_odm.normalizer.backed_enum', '@dunglas_doctrine_json_odm.normalizer.datetime', '@dunglas_doctrine_json_odm.normalizer.array', '@dunglas_doctrine_json_odm.normalizer.object']
           - ['@serializer.encoder.json']
+          - '@?dunglas_doctrine_json_odm.type_mapper'
         public: true
+        autowire: false
+        autoconfigure: false
 ```
-
-As a side note: If you happen to use [Autowiring](https://symfony.com/doc/current/service_container/autowiring.html) in your `services.yaml` you might need to set `autowire: false` too. Same goes for `autoconfigure: false` in case you're using [Autoconfiguration](https://symfony.com/doc/current/service_container.html#the-autoconfigure-option).
 
 **When the namespace of a used entity changes**
 
@@ -322,7 +324,7 @@ WHERE 'AppBundle\\\Entity\\\Bar' = JSON_EXTRACT(misc, '$."#type"');
 
 ## Credits
 
-This bundle is brought to you by [Kévin Dunglas](https://dunglas.fr) and [awesome contributors](https://github.com/dunglas/doctrine-json-odm/graphs/contributors).
+This bundle is brought to you by [Kévin Dunglas](https://dunglas.dev) and [awesome contributors](https://github.com/dunglas/doctrine-json-odm/graphs/contributors).
 Sponsored by [Les-Tilleuls.coop](https://les-tilleuls.coop).
 
 ## Former Maintainers

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -5,6 +5,15 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+
+        <service id="dunglas_doctrine_json_odm.normalizer.backed_enum" class="Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer" public="false" />
+
+        <service id="dunglas_doctrine_json_odm.normalizer.datetime" class="Symfony\Component\Serializer\Normalizer\DateTimeNormalizer" public="false" />
+
+        <service id="dunglas_doctrine_json_odm.normalizer.array" class="Symfony\Component\Serializer\Normalizer\ArrayDenormalizer" public="false" />
+
+        <service id="dunglas_doctrine_json_odm.type_mapper" class="Dunglas\DoctrineJsonOdm\TypeMapper" public="false" />
+
         <service id="dunglas_doctrine_json_odm.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
             <argument>null</argument><!-- name converter -->
@@ -13,18 +22,10 @@
             <argument type="service" id="serializer.mapping.class_discriminator_resolver" on-invalid="ignore" />
         </service>
 
-        <service id="dunglas_doctrine_json_odm.normalizer.array" class="Symfony\Component\Serializer\Normalizer\ArrayDenormalizer" public="false" />
-
-        <service id="dunglas_doctrine_json_odm.normalizer.datetime" class="Symfony\Component\Serializer\Normalizer\DateTimeNormalizer" public="false" />
-
-        <service id="dunglas_doctrine_json_odm.normalizer.backed_enum" class="Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer" public="false" />
-
-        <service id="dunglas_doctrine_json_odm.type_mapper" class="Dunglas\DoctrineJsonOdm\TypeMapper" public="false" />
-
         <service id="dunglas_doctrine_json_odm.serializer" class="Dunglas\DoctrineJsonOdm\Serializer" public="true">
             <argument type="collection">
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.backed_enum" on-invalid="ignore" />
-                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.datetime" on-invalid="ignore" />
+                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.datetime" />
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.array" />
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.object" />
             </argument>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -15,6 +15,8 @@
 
         <service id="dunglas_doctrine_json_odm.normalizer.array" class="Symfony\Component\Serializer\Normalizer\ArrayDenormalizer" public="false" />
 
+        <service id="dunglas_doctrine_json_odm.normalizer.datetime" class="Symfony\Component\Serializer\Normalizer\DateTimeNormalizer" public="false" />
+
         <service id="dunglas_doctrine_json_odm.normalizer.backed_enum" class="Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer" public="false" />
 
         <service id="dunglas_doctrine_json_odm.type_mapper" class="Dunglas\DoctrineJsonOdm\TypeMapper" public="false" />
@@ -22,6 +24,7 @@
         <service id="dunglas_doctrine_json_odm.serializer" class="Dunglas\DoctrineJsonOdm\Serializer" public="true">
             <argument type="collection">
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.backed_enum" on-invalid="ignore" />
+                <argument type="service" id="dunglas_doctrine_json_odm.normalizer.datetime" on-invalid="ignore" />
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.array" />
                 <argument type="service" id="dunglas_doctrine_json_odm.normalizer.object" />
             </argument>

--- a/tests/Fixtures/AppKernel.php
+++ b/tests/Fixtures/AppKernel.php
@@ -46,6 +46,7 @@ class AppKernel extends Kernel
         $container->loadFromExtension('framework', [
             'secret' => 'jsonodm',
             'test' => null,
+            'http_method_override' => false,
         ]);
 
         $container->loadFromExtension('doctrine', [


### PR DESCRIPTION
Without it, serializing DateTimeInterface instances leads to huge serialized data.