### PR TITLE
refactor: use const for JsonDocumentType name

### DIFF
--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -20,6 +20,8 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 final class JsonDocumentType extends JsonType
 {
+    public const NAME = 'json_document';
+
     /**
      * @var SerializerInterface
      */
@@ -119,6 +121,6 @@ final class JsonDocumentType extends JsonType
 
     public function getName(): string
     {
-        return 'json_document';
+        return self::NAME;
     }
 }


### PR DESCRIPTION
In order to use a constant rather than a string in my doctrine mapping, I added the constant and returned it in the getName of JsonDocumentType