### PR TITLE
Test Iterable Data

### DIFF
--- a/tests/Fixtures/TestBundle/Document/Vector.php
+++ b/tests/Fixtures/TestBundle/Document/Vector.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document;
+
+class Vector implements \Iterator
+{
+    private int $position;
+
+    private array $array;
+
+    public function __construct(array $array = null)
+    {
+        $this->array = $array ?? [];
+        $this->position = 0;
+    }
+
+    public function getArray(): array
+    {
+        return $this->array;
+    }
+
+    public function current(): mixed
+    {
+        return $this->array[$this->key()];
+    }
+	
+	public function key(): mixed
+    {
+        return $this->position;
+    }
+
+	public function next(): void
+    {
+        ++$this->position;
+    }
+
+	public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+	public function valid(): bool
+    {
+        return isset($this->array[$this->key()]);
+    }
+}

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -16,6 +16,7 @@ use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\Attributes;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\Bar;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\Baz;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\ScalarValue;
+use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\Vector;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\WithMappedType;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Foo;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Enum\InputMode;
@@ -222,5 +223,17 @@ class SerializerTest extends AbstractKernelTestCase
         $restoredValue = $serializer->deserialize($data, '', 'json');
 
         $this->assertEquals($value, $restoredValue);
+    }
+
+    public function testIterable(): void
+    {
+        $serializer = self::$kernel->getContainer()->get('dunglas_doctrine_json_odm.serializer');
+
+        $vector = new Vector([1,2,3,4,5]);
+
+        $data = $serializer->serialize($vector, 'json');
+        $restoredVector = $serializer->deserialize($data, '', 'json');
+
+        $this->assertEquals($vector, $restoredVector);
     }
 }


### PR DESCRIPTION
This isn't meant to be merged, it's just a test case illustrating that the serializer doesn't play nice with classes implementing \Iterator

If you clone this branch, run the tests, and put a breakpoint before the assert in `testIterable`, you'll see the serialized output of the Vector class in `$data` is:
```json
{"#type":"Dunglas\\DoctrineJsonOdm\\Tests\\Fixtures\\TestBundle\\Document\\Vector","0":1,"1":2,"2":3,"3":4,"4":5}
```
Which cannot be deserialized and the test fails

If you remove the \Iterator interface from the Vector class and re-run the tests, this is the serialized output in `$data`:
```json
{"#type":"Dunglas\\DoctrineJsonOdm\\Tests\\Fixtures\\TestBundle\\Document\\Vector","array":[1,2,3,4,5]}
```
Which can be deserialized and the test passes