### PR TITLE
Fix DI Extension class deprecation with Symfony 7.1

### DIFF
--- a/src/Bundle/DependencyInjection/DunglasDoctrineJsonOdmExtension.php
+++ b/src/Bundle/DependencyInjection/DunglasDoctrineJsonOdmExtension.php
@@ -11,9 +11,9 @@ namespace Dunglas\DoctrineJsonOdm\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\UidNormalizer;
 


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Presta\SitemapBundle\DependencyInjection\PrestaSitemapExtension".