### PR TITLE
fix: work with normalized object data as with `ArrayAccess`

### DIFF
--- a/src/SerializerTrait.php
+++ b/src/SerializerTrait.php
@@ -54,9 +54,8 @@ trait SerializerTrait
                 $typeName = $this->typeMapper->getTypeByClass($typeName);
             }
 
-            $typeData = [self::KEY_TYPE => $typeName];
-            $valueData = is_scalar($normalizedData) ? [self::KEY_SCALAR => $normalizedData] : $normalizedData;
-            $normalizedData = array_merge($typeData, $valueData);
+            $normalizedData = is_scalar($normalizedData) ? [self::KEY_SCALAR => $normalizedData] : $normalizedData;
+            $normalizedData[self::KEY_TYPE] = $typeName;
         }
 
         return $normalizedData;
@@ -69,7 +68,7 @@ trait SerializerTrait
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {
-        if (\is_array($data) && (isset($data[self::KEY_TYPE]))) {
+        if ((\is_array($data) || $data instanceof \ArrayObject) && (isset($data[self::KEY_TYPE]))) {
             $keyType = $data[self::KEY_TYPE];
 
             if ($this->typeMapper) {
@@ -84,7 +83,7 @@ trait SerializerTrait
             return parent::denormalize($data, $keyType, $format, $context);
         }
 
-        if (is_iterable($data)) {
+        if (is_iterable($data) && !$data instanceof \ArrayObject) {
             $type = ('' === $type) ? 'stdClass' : $type;
 
             return parent::denormalize($data, $type.'[]', $format, $context);

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -19,6 +19,7 @@ use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\ScalarValue;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Document\WithMappedType;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Entity\Foo;
 use Dunglas\DoctrineJsonOdm\Tests\Fixtures\TestBundle\Enum\InputMode;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\UuidV4;
 
 /**
@@ -240,5 +241,29 @@ class SerializerTest extends AbstractKernelTestCase
         $restoredValue = $serializer->deserialize($data, '', 'json');
 
         $this->assertEquals($value, $restoredValue);
+    }
+
+    public function testArrayObjectNormalization(): void
+    {
+        $serializer = self::$kernel->getContainer()->get('dunglas_doctrine_json_odm.serializer');
+
+        $data = $serializer->normalize(new Bar(), 'json', [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,
+            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
+        ]);
+
+        $this->assertInstanceOf(\ArrayObject::class, $data);
+        $this->assertArrayHasKey('#type', $data);
+        $this->assertSame(Bar::class, $data['#type']);
+    }
+
+    public function testArrayObjectDenormalization(): void
+    {
+        $serializer = self::$kernel->getContainer()->get('dunglas_doctrine_json_odm.serializer');
+
+        $data = $serializer->denormalize(new \ArrayObject(['#type' => Bar::class]), '', 'json');
+
+        $this->assertInstanceOf(Bar::class, $data);
     }
 }


### PR DESCRIPTION
Fixes #149

These changes add support for `ArrayObject` as a result of object normalization and cover issue #149 with test.