### PR TITLE
dependencies : allow symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
   "require": {
     "php": ">=8.1",
     "doctrine/orm": "^2.6.3 || ^3.0.0",
-    "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
-    "symfony/property-info": "^5.4 || ^6.0 || ^7.0",
-    "symfony/serializer": "^5.4 || ^6.0 || ^7.0"
+    "symfony/property-access": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/property-info": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/serializer": "^5.4 || ^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "doctrine/annotations": "^1.0 || ^2.0.0",
     "doctrine/doctrine-bundle": "^1.12.13 || ^2.2",
     "doctrine/dbal": "^2.7 || ^3.3 || ^4.0.0",
-    "symfony/finder": "^5.4 || ^6.0 || ^7.0",
-    "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
-    "symfony/phpunit-bridge": "^6.0 || ^7.0",
-    "symfony/uid": "^5.4 || ^6.0 || ^7.0",
-    "symfony/validator": "^5.4 || ^6.0 || ^7.0"
+    "symfony/finder": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/phpunit-bridge": "^6.0 || ^7.0 || ^8.0",
+    "symfony/uid": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/validator": "^5.4 || ^6.0 || ^7.0 || ^8.0"
   },
   "suggest": {
     "symfony/framework-bundle": "To use the provided bundle.",


### PR DESCRIPTION
Symfony 8 is soon to be released (https://symfony.com/releases/8.0)
8.0.0 RC3 was released 5 days ago.

I've added ^8.0 as an allowed version for symfony dependencies on this project.