### PR TITLE
Do not do a double denormalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "doctrine/orm": "^2.6.3 || ^3.0",
     "symfony/property-access": "^5.4 || ^6.4 || ^7.4 || ^8.0",
     "symfony/property-info": "^5.4 || ^6.4 || ^7.4 || ^8.0",
-    "symfony/serializer": "^5.4 || ^6.4 || ^7.4 || ^8.0"
+    "symfony/serializer": "^5.4 || ^6.4.43 || ^7.4.15 || ^8.0.15 || ^8.1.3"
   },
   "require-dev": {
     "doctrine/annotations": "^1.0 || ^2.0",

--- a/src/SerializerTrait.php
+++ b/src/SerializerTrait.php
@@ -78,10 +78,7 @@ trait SerializerTrait
 
             unset($data[self::KEY_TYPE]);
 
-            $data = $data[self::KEY_SCALAR] ?? $data;
-            $data = $this->denormalize($data, $keyType, $format, $context);
-
-            return parent::denormalize($data, $keyType, $format, $context);
+            return parent::denormalize($data[self::KEY_SCALAR] ?? $data, $keyType, $format, $context);
         }
 
         if (is_iterable($data)) {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -29,13 +29,8 @@ class FunctionalTest extends AbstractKernelTestCase
     {
         parent::setUp();
 
-        $this->runCommand('doctrine:schema:drop --force');
-        $this->runCommand('doctrine:schema:create');
-    }
-
-    private function runCommand($command): void
-    {
-        $this->application->run(new StringInput($command.' --no-interaction --quiet'));
+        $this->application->run(new StringInput('doctrine:schema:drop --force --no-interaction --quiet'));
+        $this->application->run(new StringInput('doctrine:schema:create --no-interaction --quiet'));
     }
 
     public function testStoreAndRetrieveDocument(): void


### PR DESCRIPTION
Symfony fixed a support check for nested array items (symfony/symfony#64649), which breaks this library as it tries to do a double denormalize