### PR TITLE
Fix running tests with newer PHPUnit

### DIFF
--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -29,13 +29,8 @@ class FunctionalTest extends AbstractKernelTestCase
     {
         parent::setUp();
 
-        $this->runCommand('doctrine:schema:drop --force');
-        $this->runCommand('doctrine:schema:create');
-    }
-
-    private function runCommand($command): void
-    {
-        $this->application->run(new StringInput($command.' --no-interaction --quiet'));
+        $this->application->run(new StringInput('doctrine:schema:drop --force --no-interaction --quiet'));
+        $this->application->run(new StringInput('doctrine:schema:create --no-interaction --quiet'));
     }
 
     public function testStoreAndRetrieveDocument(): void


### PR DESCRIPTION
PHPUnit 9 has a static runCommand method and will throw an error on PHP8.4 when that is called non-statically