### PR TITLE
Typed object collections fail to denormalize as Foo[][] with Symfony Serializer TypeInfo (no supporting normalizer found)

### DIFF
--- a/src/SerializerTrait.php
+++ b/src/SerializerTrait.php
@@ -86,8 +86,11 @@ trait SerializerTrait
 
         if (is_iterable($data)) {
             $type = ('' === $type) ? 'stdClass' : $type;
+            if (!str_ends_with($type, '[]')) {
+                $type .= '[]';
+            }
 
-            return parent::denormalize($data, $type.'[]', $format, $context);
+            return parent::denormalize($data, $type, $format, $context);
         }
 
         return $data;


### PR DESCRIPTION
This bugfix prevents having types ending with "[][]".
This surfaced when Serializer started reliably denormalizing typed collections via Foo[] (TypeInfo / PropertyTypeExtractorInterface::getType()).